### PR TITLE
Disable TeX ligatures in monospace family

### DIFF
--- a/tex/latex/sourcecodepro/sourcecodepro.sty
+++ b/tex/latex/sourcecodepro/sourcecodepro.sty
@@ -101,14 +101,12 @@
 		\fi
 	\fi
 	
-	% Shared features
+	% Monospace font
 	\defaultfontfeatures{
-		Ligatures = TeX ,
 		Numbers   = \sourcecodepro@figurestyle ,
 		Scale     = \SourceCodePro@scale ,
 		Extension = .otf }
 	
-	% Monospace font
 	\ifsourcecodepro@ttdefault
 		\setmonofont
 			[ UprightFont    = *-\sourcecodepro@regstyle ,
@@ -117,6 +115,13 @@
 			  BoldItalicFont = *-\sourcecodepro@boldstyle It ]
 			{SourceCodePro}
 	\fi
+	
+	% Shared features
+	\defaultfontfeatures{
+		Ligatures = TeX ,
+		Numbers   = \sourcecodepro@figurestyle ,
+		Scale     = \SourceCodePro@scale ,
+		Extension = .otf }
 	
 	% Font families
 	% Regular/Bold


### PR DESCRIPTION
Currently, using `"` in a monospace block results in a curly quote, which is not what I'd expect from a monospace font.

Fix borrowed from https://tex.stackexchange.com/questions/354873/xelatex-sourcecodepro-listings-curly-quotes-always